### PR TITLE
Added a null or empty check for the card name before we try to use it.

### DIFF
--- a/DailyArenaDeckAdvisor/MainWindow.xaml.cs
+++ b/DailyArenaDeckAdvisor/MainWindow.xaml.cs
@@ -715,7 +715,13 @@ namespace DailyArena.DeckAdvisor
 
 						try
 						{
-							if (_standardBannings.Contains(cardName))
+							if (string.IsNullOrWhiteSpace(cardName))
+							{
+								Logger.Debug("Empty card name found, ignore this deck", cardName);
+								ignoreDeck = true;
+								break;
+							}
+							else if (_standardBannings.Contains(cardName))
 							{
 								Logger.Debug("{cardName} is banned in standard, ignore this deck", cardName);
 								ignoreDeck = true;


### PR DESCRIPTION
On startup it would get an unhandled exception. The problem is a null card in one of the decklists it tries to compare. I added a check for a null or empty card name and to ignore the deck if so.

It said existing Issue 175 was found but I don't think that issue is the exact same as this one. I attached the logs for verification of the error.

[log2020041907.txt](https://github.com/jceddy/DailyArenaDeckAdvisor/files/4499252/log2020041907.txt)
[firstChanceExceptions2020041907.txt](https://github.com/jceddy/DailyArenaDeckAdvisor/files/4499253/firstChanceExceptions2020041907.txt)

